### PR TITLE
Improve use of foreman start hook

### DIFF
--- a/foreman_nutanix/app/models/foreman_nutanix/nutanix.rb
+++ b/foreman_nutanix/app/models/foreman_nutanix/nutanix.rb
@@ -226,23 +226,10 @@ module ForemanNutanix
       raise e
     end
 
-    # Called by Foreman after host orchestration completes
-    # This is where we exit build mode for bare VM provisioning
-    def setHostForOrchestration(host)
-      Rails.logger.info "=== NUTANIX: setHostForOrchestration called for host: #{host.name} ==="
-      super if defined?(super)
-
-      # Auto-exit build mode for bare VM provisioning
-      # Since we're not installing an OS, the host will never callback naturally
-      if host && host.build?
-        Rails.logger.info "=== NUTANIX: Auto-exiting build mode for host #{host.name} ==="
-        host.build = false
-        host.save!
-      end
-    rescue StandardError => e
-      Rails.logger.error "=== NUTANIX: Error in setHostForOrchestration: #{e.message} ==="
-      # Don't fail the whole provisioning if this fails
-    end
+    # Note: Power-on after provisioning is handled by Foreman's built-in
+    # setComputePowerUp orchestration task (priority 1000) which runs last.
+    # It's triggered when compute_attributes[:start] == '1' and calls start_vm(uuid).
+    # VMs are always created in OFF state by the shim server.
 
     # New VM instance (not persisted)
     def new_vm(attr = {})

--- a/foreman_nutanix/app/models/foreman_nutanix/nutanix_compute.rb
+++ b/foreman_nutanix/app/models/foreman_nutanix/nutanix_compute.rb
@@ -6,7 +6,7 @@ module ForemanNutanix
       :cpus, :memory, :power_state, :subnet_ext_id,
       :storage_container_ext_id, :num_sockets, :num_cores_per_socket,
       :disk_size_bytes, :description, :network_id, :storage_container,
-      :disk_size_gb, :power_on, :mac_address, :vm_ip_addresses, :create_time,
+      :disk_size_gb, :mac_address, :vm_ip_addresses, :create_time,
       :boot_method, :secure_boot, :gpus
 
     def initialize(cluster = nil, args = {})
@@ -30,7 +30,6 @@ module ForemanNutanix
       @network_id = args[:network_id] || args[:network]
       @storage_container = args[:storage_container]
       @disk_size_gb = args[:disk_size_gb] || 50
-      @power_on = args.key?(:power_on) ? args[:power_on] : true # Default to true
       @subnet_ext_id = args[:subnet_ext_id] || @network_id
       @storage_container_ext_id = args[:storage_container_ext_id] || @storage_container
       @num_sockets = args[:num_sockets] || 1
@@ -79,6 +78,10 @@ module ForemanNutanix
         raise StandardError, 'Storage Container is required for VM provisioning'
       end
 
+      # Note: VMs are always provisioned in OFF state.
+      # Power-on is handled by Foreman's built-in setComputePowerUp orchestration
+      # task (priority 1000) which runs after all other provisioning steps complete.
+      # It's triggered when compute_attributes[:start] == '1'.
       provision_request = {
         name: @name,
         cluster_ext_id: @cluster,
@@ -89,7 +92,6 @@ module ForemanNutanix
         memory_size_bytes: memory_bytes,
         disk_size_bytes: actual_disk_bytes.to_i,
         description: @description || '',
-        power_on: @power_on.nil? || @power_on, # Default to true if not set
         secure_boot: @secure_boot,
         boot_method: @boot_method,
       }

--- a/foreman_nutanix/app/views/compute_resources_vms/form/nutanix/_base.html.erb
+++ b/foreman_nutanix/app/views/compute_resources_vms/form/nutanix/_base.html.erb
@@ -67,12 +67,12 @@ compute_resource.available_storage_containers,
 } %>
 
 <%= checkbox_f f,
-:power_on,
+:start,
 {
-  label: _("Power On After Creation"),
+  label: _("Start After Creation"),
   help_inline:
     _(
-      "Automatically power on the VM after it is created. If power-on fails, the VM will be deleted.",
+      "Start the VM after Foreman completes all provisioning steps (DHCP, DNS, TFTP, etc.)",
     ),
   checked: true,
 } %>

--- a/foreman_nutanix/lib/foreman_nutanix/version.rb
+++ b/foreman_nutanix/lib/foreman_nutanix/version.rb
@@ -1,3 +1,3 @@
 module ForemanNutanix
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end

--- a/nutanix-shim-server/pyproject.toml
+++ b/nutanix-shim-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nutanix-shim-server"
-version = "0.1.2"
+version = "0.1.3"
 description = "Server for the Foreman Nutanix shim plugin"
 readme = "README.md"
 authors = [

--- a/nutanix-shim-server/src/nutanix_shim_server/vmm.py
+++ b/nutanix-shim-server/src/nutanix_shim_server/vmm.py
@@ -299,113 +299,9 @@ class VirtualMachineMgmt:
                         vm_ext_id = entity.ext_id
                         logger.info(f"VM created successfully with ext_id: {vm_ext_id}")
 
-                        # Handle power-on if requested
-                        if request.power_on:
-                            try:
-                                logger.info(
-                                    f"Power-on requested, powering on VM {vm_ext_id}..."
-                                )
-                                # Fetch VM to get ETag (required for power-on operation)
-                                get_resp = self.vms_api.get_vm_by_id(extId=vm_ext_id)
-                                etag = self.client.get_etag(get_resp)
-                                self.vms_api.power_on_vm(extId=vm_ext_id, if_match=etag)
-
-                                # Verify VM actually powered on
-                                logger.info(f"Verifying VM power state...")
-                                power_on_verified = False
-                                power_check_timeout = 60  # 60 seconds to power on
-                                power_check_interval = 3
-                                power_elapsed = 0
-
-                                while power_elapsed < power_check_timeout:
-                                    try:
-                                        power_resp = self.vms_api.get_vm_by_id(
-                                            extId=vm_ext_id
-                                        )
-                                        vm_data = power_resp.data  # type: ignore
-                                        current_power_state = (
-                                            str(vm_data.power_state)
-                                            if vm_data.power_state
-                                            else "UNKNOWN"
-                                        )
-                                        logger.info(
-                                            f"Current power state: {current_power_state}"
-                                        )
-
-                                        if current_power_state == "ON":
-                                            logger.info(
-                                                f"VM {vm_ext_id} successfully powered on"
-                                            )
-                                            power_on_verified = True
-                                            break
-
-                                        time.sleep(power_check_interval)
-                                        power_elapsed += power_check_interval
-                                    except Exception as check_error:
-                                        logger.warning(
-                                            f"Error checking power state: {check_error}"
-                                        )
-                                        time.sleep(power_check_interval)
-                                        power_elapsed += power_check_interval
-
-                                if not power_on_verified:
-                                    # Power-on failed, rollback by deleting the VM
-                                    error_msg = f"VM created but failed to power on within {power_check_timeout} seconds"
-                                    logger.error(
-                                        f"{error_msg}, rolling back by deleting VM {vm_ext_id}"
-                                    )
-
-                                    try:
-                                        # Delete the VM
-                                        get_resp = self.vms_api.get_vm_by_id(
-                                            extId=vm_ext_id
-                                        )
-                                        etag = self.client.get_etag(get_resp)
-                                        self.vms_api.delete_vm_by_id(
-                                            extId=vm_ext_id, if_match=etag
-                                        )
-                                        logger.info(
-                                            f"VM {vm_ext_id} deleted successfully during rollback"
-                                        )
-                                    except Exception as delete_error:
-                                        logger.error(
-                                            f"Failed to delete VM during rollback: {delete_error}"
-                                        )
-                                        error_msg += f". Additionally, failed to delete VM: {delete_error}"
-
-                                    raise RuntimeError(error_msg)
-
-                            except RuntimeError:
-                                # Re-raise RuntimeError from power-on verification failure
-                                raise
-                            except Exception as power_error:
-                                # Power-on command itself failed, rollback
-                                error_msg = f"Failed to power on VM: {power_error}"
-                                logger.error(
-                                    f"{error_msg}, rolling back by deleting VM {vm_ext_id}"
-                                )
-
-                                try:
-                                    # Delete the VM
-                                    get_resp = self.vms_api.get_vm_by_id(
-                                        extId=vm_ext_id
-                                    )
-                                    etag = self.client.get_etag(get_resp)
-                                    self.vms_api.delete_vm_by_id(
-                                        extId=vm_ext_id, if_match=etag
-                                    )
-                                    logger.info(
-                                        f"VM {vm_ext_id} deleted successfully during rollback"
-                                    )
-                                except Exception as delete_error:
-                                    logger.error(
-                                        f"Failed to delete VM during rollback: {delete_error}"
-                                    )
-                                    error_msg += f". Additionally, failed to delete VM: {delete_error}"
-
-                                raise RuntimeError(error_msg)
-                        else:
-                            logger.info("Power-on not requested, VM will remain off")
+                        # Note: Power-on is handled separately by Foreman after
+                        # orchestration completes, not during provisioning.
+                        # Use the set_vm_power_state endpoint to power on the VM.
 
                         return VmMetadata(
                             ext_id=vm_ext_id,
@@ -667,6 +563,9 @@ class VmProvisionRequest:
     """
     Request model for provisioning a new VM.
 
+    Note: VMs are always created in OFF state. Power-on is handled separately
+    by calling the set_vm_power_state endpoint after Foreman orchestration completes.
+
     Example:
         {
             "name": "my-vm-01",
@@ -678,7 +577,6 @@ class VmProvisionRequest:
             "num_cores_per_socket": 2,
             "memory_size_bytes": 8589934592,  # 8 GB
             "disk_size_bytes": 107374182400,   # 100 GB
-            "power_on": true,                  # Auto power-on after creation
             "boot_method": "uefi",             # uefi | bios
             "secure_boot": true,               # secure boot conf - applicable only to UEFI
         }
@@ -693,7 +591,6 @@ class VmProvisionRequest:
     memory_size_bytes: int
     disk_size_bytes: int
     description: str = ""
-    power_on: bool = True
     boot_method: Literal["bios", "uefi"] = "uefi"
     secure_boot: bool = False
 

--- a/nutanix-shim-server/uv.lock
+++ b/nutanix-shim-server/uv.lock
@@ -638,7 +638,7 @@ wheels = [
 
 [[package]]
 name = "nutanix-shim-server"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },

--- a/nutanix-shim-server/uv.lock
+++ b/nutanix-shim-server/uv.lock
@@ -638,7 +638,7 @@ wheels = [
 
 [[package]]
 name = "nutanix-shim-server"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },


### PR DESCRIPTION
Remove starting the VM immediately after provisioning, to instead depend better on foreman's built in hooks (set 'start' on compute) which then will invoke shim server again to set the power state after provisioning is done on foreman's side.